### PR TITLE
Fix bug in question answer display

### DIFF
--- a/aml_mastermind_final.py
+++ b/aml_mastermind_final.py
@@ -108,24 +108,14 @@ if st.session_state.step == "quiz":
         q = questions[idx]
         st.markdown(f"### Q{idx + 1}: {q['question']}")
         st.progress((idx + 1) / len(questions))
-        with st.form(key=f"form_{idx}"):        
-            shuffle_key = f"shuffled_{idx}"
+        shuffle_key = f"shuffled_{idx}"
         if shuffle_key not in st.session_state:
-            opts = q["options"].copy()
-            random.shuffle(opts)
+            opts = q["options"]
             st.session_state[shuffle_key] = opts
         else:
             opts = st.session_state[shuffle_key]
 
-            sel = st.radio("Choose an answer:", opts, key=f"answer_{idx}")
-
-
-
-
-            sel = st.radio("Choose an answer:", opts, key=f"answer_{idx}")
-
-            opts = q["options"].copy()
-            random.shuffle(opts)
+        with st.form(key=f"form_{idx}"):
             sel = st.radio("Choose an answer:", opts, key=f"answer_{idx}")
             submitted = st.form_submit_button("Submit")
 


### PR DESCRIPTION
## Summary
- fix option shuffling logic in Streamlit quiz
- remove option randomization

## Testing
- `python -m py_compile aml_mastermind_final.py`
- `python aml_mastermind_final.py` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_684832d99838832897bfc54068c5997a